### PR TITLE
Only handle form submit event when form not valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aspnet-client-validation",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Enables ASP.NET MVC client-side validation, without jQuery!",
   "main": "dist/aspnet-validation.js",
   "style": "dist/aspnet-validation.css",

--- a/src/index.ts
+++ b/src/index.ts
@@ -627,18 +627,18 @@ export class ValidationService {
                 return;
             }
 
-            let isProgrammaticValidate = !e;
-            if (!isProgrammaticValidate) {
-                e.preventDefault();
-            }
             validate.then(success => {
+                let isProgrammaticValidate = !e;
                 if (success) {
                     if (isProgrammaticValidate) {
                         callback(true);
                         return;
                     }
-                    form.submit();
                     return;
+                }
+                else {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
                 }
                 if (isProgrammaticValidate) {
                     callback(false);


### PR DESCRIPTION
A form may have other event handlers attached to the `submit` event.
For example, when implementing an Ajax form. Rather than call the
`submit` method directly which bypasses those handlers, if the form is
valid, this allows the original form submit event to propagate.

However, if the form is invalid, this stops propagation of the form
event entirely, even to other registered event handlers.

This requires that client validation registers its event handler on
forms first.