### PR TITLE
Adds isValid(form) method for checking whether a form is valid

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -603,6 +603,23 @@ export class ValidationService {
     }
 
     /**
+     * Returns true if the provided form is valid, and then calls the callback. The form will be validated before checking, unless prevalidate is set to false
+     * @param form 
+     * @param prevalidate 
+     * @param callback 
+     * @returns 
+     */
+    isValid = (form: HTMLFormElement, prevalidate: boolean = true, callback: Function) => {
+        if (prevalidate) {
+            this.validateForm(form, callback);
+        }
+        let formUID = this.getElementUID(form);
+        let formInputUIDs = this.formInputs[formUID];
+        let invalidFormInputUIDs = formInputUIDs.filter(uid => this.summary[uid]);
+        return invalidFormInputUIDs.length == 0;
+    }
+
+    /**
      * Tracks a <form> element as parent of an input UID. When the form is submitted, attempts to validate the said input asynchronously.
      * @param form 
      * @param inputUID 

--- a/src/index.ts
+++ b/src/index.ts
@@ -620,6 +620,26 @@ export class ValidationService {
     }
 
     /**
+     * Returns true if the provided field is valid, and then calls the callback. The form will be validated before checking, unless prevalidate is set to false
+     * @param form 
+     * @param prevalidate 
+     * @param callback 
+     * @returns 
+     */
+    isFieldValid = (field: HTMLElement, prevalidate: boolean = true, callback: Function) => {
+        
+        if (prevalidate) {
+            let form = field.closest("form");
+            if (form != null) {
+                this.validateForm(form, callback);
+            }
+        }
+
+        let fieldUID = this.getElementUID(field);
+        return this.summary[fieldUID] != null;
+    }
+
+    /**
      * Tracks a <form> element as parent of an input UID. When the form is submitted, attempts to validate the said input asynchronously.
      * @param form 
      * @param inputUID 


### PR DESCRIPTION
Hi

I'm trying to use this as a replacement for jquery-validate-unobtrusive. While doing this, I noticed that this library misses a method for checking if a specific form is valid.

So I added it.

You can use it like `v.isValid(document.querySelector("#myform"))`

By default it will try to validate the form, before returning whether the form is valid. This can be disabled by adding a false parameter like `v.isValid(document.querySelector("#myform"), false)`

You can also supply a callback function to be run after the isValid check like `v.isValid(document.querySelector("#myform"), true, () => console.log("hi"))`

For fields you can use `v.isFieldValid(document.querySelector("#myfield"))`