### PR TITLE
Fixes bug when using v.validateForm()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -641,8 +641,12 @@ export class ValidationService {
                     form.dispatchEvent(validationEvent);
                     return;
                 }
-                e.preventDefault();
-                e.stopImmediatePropagation();
+
+                if (e) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                }
+                
                 const validationEvent = new CustomEvent('validation',
                 {
                     detail: { valid: false }


### PR DESCRIPTION
When using the validateForm method for programatically validating a form, the validation fails becuase it tries to preventDefault and stopImmediaPropagation on the supplied event in the callback in trackFormInput.

This change checks if there is an event to perform the actions on.