### PR TITLE
Be less restrictive when validating urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aspnet-client-validation",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Enables ASP.NET MVC client-side validation, without jQuery!",
   "main": "dist/aspnet-validation.js",
   "style": "dist/aspnet-validation.css",

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,6 +238,7 @@ export class MvcValidationProviders {
         
         let lowerCaseValue = value.toLowerCase();
 
+        // Match the logic in `UrlAttribute`
         return lowerCaseValue.indexOf('http://') > -1
             || lowerCaseValue.indexOf('https://') > -1
             || lowerCaseValue.indexOf('ftp://') > -1; 

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,48 +235,12 @@ export class MvcValidationProviders {
         if (!value) {
             return true;
         }
+        
+        let lowerCaseValue = value.toLowerCase();
 
-        // (c) Diego Perini, MIT Licensed
-        // https://gist.github.com/dperini/729294
-
-        var r = new RegExp(
-            "^" +
-            // protocol identifier
-            "(?:(?:https?|ftp)://)" +
-            // user:pass authentication
-            "(?:\\S+(?::\\S*)?@)?" +
-            "(?:" +
-            // IP address exclusion
-            // private & local networks
-            "(?!(?:10|127)(?:\\.\\d{1,3}){3})" +
-            "(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})" +
-            "(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})" +
-            // IP address dotted notation octets
-            // excludes loopback network 0.0.0.0
-            // excludes reserved space >= 224.0.0.0
-            // excludes network & broacast addresses
-            // (first & last IP address of each class)
-            "(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])" +
-            "(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}" +
-            "(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))" +
-            "|" +
-            // host name
-            "(?:(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)" +
-            // domain name
-            "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*" +
-            // TLD identifier
-            "(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))" +
-            // TLD may end with dot
-            "\\.?" +
-            ")" +
-            // port number
-            "(?::\\d{2,5})?" +
-            // resource path
-            "(?:[/?#]\\S*)?" +
-            "$", "i"
-        );
-
-        return r.test(value);
+        return lowerCaseValue.indexOf('http://') > -1
+            || lowerCaseValue.indexOf('https://') > -1
+            || lowerCaseValue.indexOf('ftp://') > -1; 
     }
 
     /**


### PR DESCRIPTION
Use the same logic as the `UrlAttribute` which only checks the beginning of the string in a case insensitive way.

Fixes #11