### PR TITLE
When adding or removing an error from an input element, also apply it to inputs with the same name.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -934,6 +934,14 @@ export class ValidationService {
             this.ValidationInputCssClassName,
             this.ValidationInputValidCssClassName);
 
+        // Adding an error to one input should also add it to others with the same name (i.e. for radio button and checkbox lists).
+        const inputs = input.form.querySelectorAll('input[name="' + input.name + '"]');
+        for (let i = 0; i < inputs.length; i++) {
+            this.swapClasses(inputs[i],
+                this.ValidationInputCssClassName,
+                this.ValidationInputValidCssClassName);
+        }
+
         let uid = this.getElementUID(input);
         this.summary[uid] = message;
         this.renderSummary();
@@ -957,6 +965,14 @@ export class ValidationService {
         this.swapClasses(input,
             this.ValidationInputValidCssClassName,
             this.ValidationInputCssClassName);
+
+        // Removing an error from one input should also remove it from others with the same name (i.e. for radio button and checkbox lists).
+        const inputs = input.form.querySelectorAll('input[name="' + input.name + '"]');
+        for (let i = 0; i < inputs.length; i++) {
+            this.swapClasses(inputs[i],
+                this.ValidationInputValidCssClassName,
+                this.ValidationInputCssClassName);
+        }
 
         let uid = this.getElementUID(input);
         delete this.summary[uid];


### PR DESCRIPTION
We had [this issue](https://github.com/umbraco/Umbraco.Forms.Issues/issues/1028) raised on the Umbraco Forms product that uses this library for client side validation.

It seems to me a reasonable general case for input fields, particularly check box and radio button lists, that when adding or removing a class to indicate an error on an input field, that this should be applied to all inputs with the same name.

Hence this PR.

As an example, with a form containing mandatory radio button or check box lists:

![image](https://github.com/haacked/aspnet-client-validation/assets/1993459/e1b3f1bb-3f6a-4e21-943e-2e042b9fcb92)

Submitting the form triggers the client-side validation and the appropriate classes are added to all fields:

![image](https://github.com/haacked/aspnet-client-validation/assets/1993459/960d2d1d-2472-450b-862f-f58f1291022c)

Clicking a single radio or checkbox will currently remove the error only for the one you clicked on, leaving the other indicated as invalid even though now actually it's not.

With this PR all radio buttons will have the class removed.

![image](https://github.com/haacked/aspnet-client-validation/assets/1993459/b4e0c9a0-6f04-4b8a-981f-bf1a3097ddd7)

Similarly for adding errors, previously, if values were selected and removed, when the last checkbox list item was deselected, only that one would get the invalid error class.  Now all of them do:

![image](https://github.com/haacked/aspnet-client-validation/assets/1993459/17b81d28-23d9-42bd-b0ab-9c187e06e00f)

