### PR TITLE
Properly scan messages when the mutated element is a descendant of a form

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -535,6 +535,11 @@ export class ValidationService {
             // we could use 'matches', but that's newer than querySelectorAll so we'll keep it simple and compatible.
             forms.push(root);
         }
+        // If root is the descendant of a form, we want to include that form too.
+        const containingForm = (root as HTMLElement).closest('form');
+        if (containingForm) {
+            forms.push(containingForm);
+        }
 
         for (let form of forms) {
             let validationMessageElements = Array.from(form.querySelectorAll<HTMLElement>('[data-valmsg-for]'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -536,7 +536,7 @@ export class ValidationService {
             forms.push(root);
         }
         // If root is the descendant of a form, we want to include that form too.
-        const containingForm = (root as HTMLElement).closest('form');
+        const containingForm = (root instanceof Element) ? root.closest('form') : null;
         if (containingForm) {
             forms.push(containingForm);
         }


### PR DESCRIPTION
I noticed a situation in watch mode where I was adding form elements dynamically and the inputs themselves would validate, but the error messages wouldn't show up. I've modified `scanMessages` to use the `closest` method to find the enclosing form when the mutated element is a descendant of a form.

- Closes #70