### PR TITLE
Check if addClass is truthy before adding it to element

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1254,7 +1254,7 @@ export class ValidationService {
      * @param removeClass Class to remove
      */
     private swapClasses(element: Element, addClass: string, removeClass: string) {
-        if (!element.classList.contains(addClass)) {
+        if (addClass && !element.classList.contains(addClass)) {
             element.classList.add(addClass);
         }
         if (element.classList.contains(removeClass)) {


### PR DESCRIPTION
DOMTokenList::add() throws a DOMException if you try to add an empty string as a class. This check prevents this from happening so that you can set ValidationInputValidCssClassName etc. to an empty string if you don't want to add classes for valid input fields or messages for instance.