### PR TITLE
Only send checkbox/radio values for remote validation if checked

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -351,7 +351,12 @@ export class MvcValidationProviders {
                 continue;
             }
 
-            fields[fieldName] = fieldElement.value;
+            if (fieldElement instanceof HTMLInputElement &&
+                (fieldElement.type === 'checkbox' || fieldElement.type === 'radio')) {
+                fields[fieldName] = fieldElement.checked ? fieldElement.value : '';
+            } else {
+                fields[fieldName] = fieldElement.value;
+            }
         }
 
         let url: string = params['url'];


### PR DESCRIPTION
Doing remote validation for a checkbox value always sends the input's value whether the checkbox is checked or not and since the value is set to "true" for checkboxes the value will always be true on the server side even if you unchecked the checkbox when the remote validation was triggered. This change fixes this by only sending the value if the checkbox was checked. This is similar to what jquery-validation-unobtrusive does to handle remote checkbox validation.

I also added radio buttons to the check but I don't think it will work correctly for them since there will be multiple inputs with the same name selector for radio buttons but only the first one is handled which might not be the one that is clicked. So I'm not sure what the correct approach is for remote validation of radio buttons but this at least seems to be more in line with how jquery-validation-unobtrusive handles them.