### PR TITLE
Formaction on a button fix

### DIFF
--- a/Pages/Demos/FormAction.cshtml
+++ b/Pages/Demos/FormAction.cshtml
@@ -1,7 +1,6 @@
 @page
 @model DemoWeb.Pages.Demos.FormAction
 
-
 @{
     Layout = "Shared/_Layout";
 }
@@ -9,6 +8,13 @@
 <partial name="Shared/_StatusMessage" model="Model.StatusMessage"/>
 
 <form method="post">
+    <div asp-validation-summary="All">The following problems occurred when submitting the form:</div>
+    <div>
+        <label asp-for="Input.Name"></label>
+        <input asp-for="Input.Name" />
+        <span asp-validation-for="Input.Name" ></span>
+    </div>
     <input type="submit" value="Submit" asp-page-handler="Submit" />
     <input type="submit" value="Save" asp-page-handler="Save"/>
+    <input type="submit" />
 </form>

--- a/Pages/Demos/FormAction.cshtml.cs
+++ b/Pages/Demos/FormAction.cshtml.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.ComponentModel.DataAnnotations;
 
 namespace DemoWeb.Pages.Demos;
 
@@ -8,6 +9,15 @@ public class FormAction : PageModel
     [TempData]
     public string? StatusMessage { get; set; }
 
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public class InputModel
+    {
+        [Display(Name = "Name")]
+        [Required, StringLength(50)]
+        public string? Name { get; set; }
+    }
 
     public IActionResult OnPostSubmitAsync()
     {
@@ -19,6 +29,13 @@ public class FormAction : PageModel
     public IActionResult OnPostSave()
     {
         StatusMessage = "Save button clicked";
+
+        return RedirectToPage();
+    }
+
+    public IActionResult OnPost()
+    {
+        StatusMessage = "The button with no formaction was clicked";
 
         return RedirectToPage();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -796,7 +796,7 @@ export class ValidationService {
             // Because the submitter is not propagated when calling
             // form.submit(), we recreate it here.
             const submitter = submitEvent.submitter;
-            let initialFormAction = form.action;
+            const initialFormAction = form.action;
             if (submitter) {
                 const name = submitter.getAttribute('name');
                 // If name is null, a submit button is not submitted.

--- a/src/index.ts
+++ b/src/index.ts
@@ -814,9 +814,9 @@ export class ValidationService {
                 }
             }
 
-            form.submit();
-
-            if (form.action != initialFormAction) {
+            try {
+                form.submit();
+            } finally {
                 form.action = initialFormAction;
             }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -806,6 +806,11 @@ export class ValidationService {
                     submitterInput.value = submitter.getAttribute('value');
                     form.appendChild(submitterInput)
                 }
+
+                const formAction = submitter.getAttribute('formaction');
+                if (formAction) {
+                    form.action = formAction;
+                }
             }
 
             form.submit();

--- a/src/index.ts
+++ b/src/index.ts
@@ -796,6 +796,7 @@ export class ValidationService {
             // Because the submitter is not propagated when calling
             // form.submit(), we recreate it here.
             const submitter = submitEvent.submitter;
+            let initialFormAction = form.action;
             if (submitter) {
                 const name = submitter.getAttribute('name');
                 // If name is null, a submit button is not submitted.
@@ -814,6 +815,10 @@ export class ValidationService {
             }
 
             form.submit();
+
+            if (form.action != initialFormAction) {
+                form.action = initialFormAction;
+            }
         }
     }
 
@@ -830,7 +835,7 @@ export class ValidationService {
         let invalidFormInputUIDs = formInputUIDs.filter(uid => this.summary[uid]);
 
         if (invalidFormInputUIDs.length > 0) {
-            var firstInvalid = this.elementByUID[invalidFormInputUIDs[0]] as HTMLElement;
+            const firstInvalid = this.elementByUID[invalidFormInputUIDs[0]] as HTMLElement;
             if (firstInvalid) {
                 firstInvalid.focus();
             }


### PR DESCRIPTION
Fixes #39

The library has to do a bit of work to hook the form submit event, do its thing, and then recreate the submit event. However, we didn't factor in that the submit button might have a formaction attribute on it. Now we do.