### PR TITLE
Main

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1045,14 +1045,22 @@ export class ValidationService {
         let debounceTimeoutID = 0;
         let cb = (e: Event, callback?: ValidatedCallback) => {
             let validate = this.validators[uid];
-            clearTimeout(debounceTimeoutID);
-            debounceTimeoutID = setTimeout(() => {
+            if(this.debounce){
+                clearTimeout(debounceTimeoutID);
+                debounceTimeoutID = setTimeout(() => {
+                    validate()
+                        .then(callback)
+                        .catch(error => {
+                            this.logger.log('Validation error', error);
+                        });
+                }, this.debounce);
+            }else{
                 validate()
-                    .then(callback)
-                    .catch(error => {
-                        this.logger.log('Validation error', error);
-                    });
-            }, this.debounce);
+                .then(callback)
+                .catch(error => {
+                    this.logger.log('Validation error', error);
+                });
+            }
         };
 
         let validateEvent = input.dataset.valEvent;


### PR DESCRIPTION
The timer by which the `callback` argument of `validationService.validateField(field, callback)` is run, will be cancelled before the callback runs by default validation check that runs after the `input` or `change` event handler.
This PR checks to see if the `debounce` value should be used or not. If it's set to zero, the whole `setTimeout` mechanism will be bypassed.