### PR TITLE
Fix for client side 'required' validator which allowed whitespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,8 +153,9 @@ export class MvcValidationProviders {
 
             return false;
         }
-        // Default behavior otherwise.
-        return Boolean(value);
+
+        // Default behavior otherwise (trim ensures whitespace only is not seen as valid).
+        return Boolean(value?.trim());
     }
 
     /**


### PR DESCRIPTION
Fix for client side 'required' validator which allowed whitespace to be submitted in input value. This library is now works the same way as jQuery Unobtrusive validation on which it is based.

Closes #109