### PR TITLE
Slightly Improved phone validator.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -333,7 +333,7 @@ export class MvcValidationProviders {
             return false;
         }
 
-        let r = /^\+?[0-9\-\s]+$/;
+        let r = element.pattern ? new RegExp(element.pattern) : /^\+?[0-9\-\s]+$/;
         return r.test(value);
     }
 


### PR DESCRIPTION
The RegExp used in the original code was too loose for a valid Phone number and on the other hand, phone numbers have somewhat different patterns around the world. According to Mozilla[https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/tel] one should be able to use the `pattern` attribute on an `<input type="tel" /> element to indicate the RegExp to be used to validate the phone number.

This PR, takes the `pattern` attribute into account.